### PR TITLE
treat WashCavity_OpStatusDispenserDrawerOpen as optional

### DIFF
--- a/custom_components/maytag_dryer/sensor.py
+++ b/custom_components/maytag_dryer/sensor.py
@@ -361,7 +361,7 @@ class maytag_washerSensor(Entity):
                 self._serialNumber = data.get('attributes').get('XCat_ApplianceInfoSetSerialNumber').get('value')
                 self._doorOpen = data.get('attributes').get('Cavity_OpStatusDoorOpen').get('value')
                 self._doorLocked = data.get('attributes').get('Cavity_OpStatusDoorLocked').get('value')
-                self._drawerOpen = data.get('attributes').get('WashCavity_OpStatusDispenserDrawerOpen').get('value')
+                self._drawerOpen = data.get('attributes').get('WashCavity_OpStatusDispenserDrawerOpen', {}).get('value')
                 self._status = data.get('attributes').get('Cavity_CycleStatusMachineState').get('value')
                 self._cycleName = data.get('attributes').get('Cavity_CycleSetCycleName').get('value')
                 self._cycleId = data.get('attributes').get('WashCavity_CycleSetCycleSelect').get('value')


### PR DESCRIPTION
I don't see this field in the response for my MVW7230HC0 washer.  This change 
fixes this component for me.